### PR TITLE
Fix di extension method sig mismatch causing funcs to be used as serv…

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: .NET BUild
+name: .NET Build
 
 on:
   pull_request:

--- a/src/HostFixture/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HostFixture/Extensions/ServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
-namespace HostFixture.Extensions; 
+namespace HostFixture.Extensions;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection Replace(this IServiceCollection services, 
-        Type serviceType, 
-        Type instanceType, 
+    public static IServiceCollection Replace(this IServiceCollection services,
+        Type serviceType,
+        Type instanceType,
         ServiceLifetime lifetime)
     {
         services.RemoveAll(serviceType)
@@ -13,7 +13,7 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection Replace<TService, TInstance> (this IServiceCollection services,
+    public static IServiceCollection Replace<TService, TInstance>(this IServiceCollection services,
         ServiceLifetime lifetime)
     {
         services.RemoveAll(typeof(TService))
@@ -22,12 +22,23 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection Replace<TService>(this IServiceCollection services, 
-        Action<IServiceProvider, TService> factory, 
+    public static IServiceCollection Replace<TService>(this IServiceCollection services,
+        Func<IServiceProvider, object> factory,
         ServiceLifetime lifetime)
     {
         services.RemoveAll(typeof(TService))
                 .Add(new ServiceDescriptor(typeof(TService), factory, lifetime));
+
+        return services;
+    }
+
+    public static IServiceCollection Replace(this IServiceCollection services,
+        Type serviceType,
+        object instance,
+        ServiceLifetime lifetime)
+    {
+        services.RemoveAll(serviceType)
+                .Add(new ServiceDescriptor(serviceType, sp => instance, lifetime));
 
         return services;
     }

--- a/src/HostFixture/HostApplicationFixture.cs
+++ b/src/HostFixture/HostApplicationFixture.cs
@@ -30,15 +30,25 @@ public class HostApplicationFixture
 
     public IHostFixture RegisterScoped<TService>(Action<IServiceProvider, TService> factory)
     {
-        SourceBuilder.Services.Replace(factory, ServiceLifetime.Scoped);
+        SourceBuilder
+            .Services
+            .Replace(typeof(TService), factory, ServiceLifetime.Scoped);
 
         return this;
     }
 
     public IHostFixture RegisterScoped<TService>(Func<TService> factory)
     {
-        SourceBuilder.Services.Replace<TService>((sp, TService) => factory.Invoke(), ServiceLifetime.Scoped);
+        SourceBuilder
+            .Services
+            .Replace(typeof(TService), factory, ServiceLifetime.Scoped);
 
+        return this;
+    }
+
+    public IHostFixture RegisterScoped(Type serviceType, object instance)
+    {
+        SourceBuilder.Services.Replace(serviceType, instance, ServiceLifetime.Scoped);
         return this;
     }
 
@@ -53,18 +63,28 @@ public class HostApplicationFixture
 
     public IHostFixture RegisterSingleton<TService>(Action<IServiceProvider, TService> factory)
     {
-        SourceBuilder.Services.Replace(factory, ServiceLifetime.Singleton);
+        SourceBuilder
+            .Services
+            .Replace(typeof(TService), factory, ServiceLifetime.Transient);
 
         return this;
     }
 
     public IHostFixture RegisterSingleton<TService>(Func<TService> factory)
     {
-        SourceBuilder.Services.Replace<TService>((sp, TService) => factory.Invoke(), ServiceLifetime.Singleton);
+        SourceBuilder
+            .Services
+            .Replace(typeof(TService), factory, ServiceLifetime.Scoped);
 
         return this;
     }
 
+
+    public IHostFixture RegisterSingleton(Type serviceType, object instance)
+    {
+        SourceBuilder.Services.Replace(serviceType, instance, ServiceLifetime.Singleton);
+        return this;
+    }
 
     // Transient replacements
 
@@ -77,15 +97,26 @@ public class HostApplicationFixture
 
     public IHostFixture RegisterTransient<TService>(Action<IServiceProvider, TService> factory)
     {
-        SourceBuilder.Services.Replace(factory, ServiceLifetime.Transient);
+        SourceBuilder
+            .Services
+            .Replace(typeof(TService), factory, ServiceLifetime.Transient);
 
         return this;
     }
 
     public IHostFixture RegisterTransient<TService>(Func<TService> factory)
     {
-        SourceBuilder.Services.Replace<TService>((sp, TService) => factory.Invoke(), ServiceLifetime.Transient);
+        SourceBuilder
+            .Services
+            .Replace(typeof(TService), factory, ServiceLifetime.Transient);
 
         return this;
     }
+
+    public IHostFixture RegisterTransient(Type serviceType, object instance)
+    {
+        SourceBuilder.Services.Replace(serviceType, instance, ServiceLifetime.Transient);
+        return this;
+    }
+
 }

--- a/src/HostFixture/HostFixture.cs
+++ b/src/HostFixture/HostFixture.cs
@@ -31,7 +31,7 @@ public class HostFixture
     public IHostFixture RegisterScoped<TService>(Action<IServiceProvider, TService> factory)
     {
         SourceBuilder.ConfigureServices(services
-            => services.Replace(factory, ServiceLifetime.Scoped));
+            => services.Replace(typeof(TService), factory, ServiceLifetime.Scoped));
 
         return this;
     }
@@ -39,10 +39,27 @@ public class HostFixture
     public IHostFixture RegisterScoped<TService>(Func<TService> factory)
     {
         SourceBuilder.ConfigureServices(services
-            => services.Replace<TService>((sp, TService) => factory.Invoke(), ServiceLifetime.Scoped));
+            => services.Replace(typeof(TService), factory, ServiceLifetime.Scoped));
 
         return this;
     }
+    
+    public IHostFixture RegisterScoped(Type serviceType, Type implementationType)
+    {
+        SourceBuilder.ConfigureServices(services
+            => services.Replace(serviceType, implementationType, ServiceLifetime.Scoped));
+
+        return this;
+    }
+
+    public IHostFixture RegisterScoped(Type serviceType, object instance)
+    {
+        SourceBuilder.ConfigureServices(services
+            => services.Replace(serviceType, instance, ServiceLifetime.Scoped));
+
+        return this;
+    }
+
 
     // Singleton replacements
 
@@ -57,7 +74,7 @@ public class HostFixture
     public IHostFixture RegisterSingleton<TService>(Action<IServiceProvider, TService> factory)
     {
         SourceBuilder.ConfigureServices(services
-            => services.Replace(factory, ServiceLifetime.Singleton));
+            => services.Replace(typeof(TService), factory, ServiceLifetime.Singleton));
 
         return this;
     }
@@ -65,10 +82,19 @@ public class HostFixture
     public IHostFixture RegisterSingleton<TService>(Func<TService> factory)
     {
         SourceBuilder.ConfigureServices(services
-            => services.Replace<TService>((sp, TService) => factory.Invoke(), ServiceLifetime.Singleton));
+            => services.Replace(typeof(TService), factory, ServiceLifetime.Singleton));
 
         return this;
     }
+
+    public IHostFixture RegisterSingleton(Type serviceType, object instance)
+    {
+        SourceBuilder.ConfigureServices(services
+            => services.Replace(serviceType, instance, ServiceLifetime.Singleton));
+
+        return this;
+    }
+
 
 
     // Transient replacements
@@ -84,7 +110,7 @@ public class HostFixture
     public IHostFixture RegisterTransient<TService>(Action<IServiceProvider, TService> factory)
     {
         SourceBuilder.ConfigureServices(services
-            => services.Replace(factory, ServiceLifetime.Transient));
+            => services.Replace(typeof(TService), factory, ServiceLifetime.Transient));
 
         return this;
     }
@@ -92,7 +118,15 @@ public class HostFixture
     public IHostFixture RegisterTransient<TService>(Func<TService> factory)
     {
         SourceBuilder.ConfigureServices(services
-            => services.Replace<TService>((sp, TService) => factory.Invoke(), ServiceLifetime.Transient));
+            => services.Replace(typeof(TService), factory, ServiceLifetime.Transient));
+
+        return this;
+    }
+
+    public IHostFixture RegisterTransient(Type serviceType, object instance)
+    {
+        SourceBuilder.ConfigureServices(services
+            => services.Replace(serviceType, instance, ServiceLifetime.Transient));
 
         return this;
     }

--- a/src/HostFixture/IHostFixture.cs
+++ b/src/HostFixture/IHostFixture.cs
@@ -31,6 +31,15 @@ public interface IHostFixture
 
 
     /// <summary>
+    /// Registers a provided instance as Singleton, replacing any existing registration regardless of the lifetime.
+    /// </summary>
+    /// <param name="serviceType">The type of service being registered. Used to resolve existing registrations</param>
+    /// <param name="instance">The instance being added to the service collection</param>
+    /// <returns>This IHostFixture to chain additional commands</returns>
+    public IHostFixture RegisterSingleton(Type serviceType, object instance);
+
+
+    /// <summary>
     /// Registers a TIstance of TService as Scoped, replacing any existing registration regardless of the lifetime.
     /// </summary>
     /// <typeparam name="TService">The type of service being registered. Used to resolve existing registrations</typeparam>
@@ -54,6 +63,15 @@ public interface IHostFixture
     /// <returns>This IHostFixture to chain additional commands</returns>
     /// <remarks>
     public IHostFixture RegisterScoped<TService>(Func<TService> factory);
+
+
+    /// <summary>
+    /// Registers a provided instance as a Scoped, replacing any existing registration regardless of the lifetime.
+    /// </summary>
+    /// <param name="serviceType">The type of service being registered. Used to resolve existing registrations</param>
+    /// <param name="instance">The instance being added to the service collection</param>
+    /// <returns>This IHostFixture to chain additional commands</returns>
+    public IHostFixture RegisterScoped(Type serviceType, object instance);
 
     /// <summary>
     /// Registers a TIstance of TService as Transient, replacing any existing registration regardless of the lifetime.
@@ -80,6 +98,14 @@ public interface IHostFixture
     /// <returns>This IHostFixture to chain additional commands</returns>
     /// <remarks>
     public IHostFixture RegisterTransient<TService>(Func<TService> factory);
+
+    /// <summary>
+    /// Registers a provided instance as Transient, replacing any existing registration regardless of the lifetime.
+    /// </summary>
+    /// <param name="serviceType">The type of service being registered. Used to resolve existing registrations</param>
+    /// <param name="instance">The instance being added to the service collection</param>
+    /// <returns>This IHostFixture to chain additional commands</returns>
+    public IHostFixture RegisterTransient(Type serviceType, object instance);
 
 }
 

--- a/test/HostFixtureTests/BaseExtensionTests.cs
+++ b/test/HostFixtureTests/BaseExtensionTests.cs
@@ -14,7 +14,7 @@ public class BaseExtensionTests
         // Arrange
         var builder = new HostBuilder();
 
-        builder.ConfigureFixture(); 
+        builder.ConfigureFixture();
 
         // Assert
         Assert.NotNull(builder);
@@ -26,6 +26,8 @@ public class BaseExtensionTests
     public void should_replace_service_collection_entries()
     {
         // Arrange
+        var mock = new Mock<IStringService>();
+        mock.Setup(x => x.GenerateRandomString(It.IsAny<int>())).Returns("I'm a mocked service!");
 
         // Grab the IHostBuilder property from the Program class of the SUT project 
         var builder = Program.CreateBuilder(Array.Empty<string>());
@@ -33,20 +35,18 @@ public class BaseExtensionTests
         // Act
         builder
             .ConfigureFixture()
-            .RegisterTransient(() => 
-            {
-                // Create and register mock services fluently!!
-
-                var mock = new Mock<IStringService>();
-                mock.Setup(x => x.GenerateRandomString(It.IsAny<int>())).Returns("I'm a mocked service!");
-                return mock.Object;
-            }); 
+            .RegisterTransient(typeof(IStringService), mock.Object);
 
         var fixturedHost = builder.Build();
 
         // Assert
         // We expect our mocked IStringService to be resolved as a StringService
+
         var service = fixturedHost.Services.GetRequiredService<IStringService>();
+
+
+
+
         Assert.NotNull(service);
     }
 }


### PR DESCRIPTION
Method signature was causing the argued func itself to be used as a service key. This caused registered services to be inaccessible without a key, causing injection to fail